### PR TITLE
Fix Case Sensitivity Issue in Run-Benchmark-Script

### DIFF
--- a/run-benchmarking-tool.sh
+++ b/run-benchmarking-tool.sh
@@ -75,6 +75,8 @@ if ! [[ "$SV2_INTERVAL" =~ ^[0-9]+$ ]]; then
     exit 1
 fi
 
+CONFIG=$(echo "$CONFIG" | tr '[:upper:]' '[:lower:]')
+
 # Determine the correct TOML file based on configuration
 config_file="./custom-configs/sri-roles/config-${CONFIG}/tproxy-config-${CONFIG}-docker-example.toml"
 


### PR DESCRIPTION
By default, the macOS file system is typically case-insensitive, meaning it doesn't distinguish between files named 'Config-A' and 'config-a'. However, Linux file systems are case-sensitive, so 'config-A' and 'config-a' are considered distinct. This PR changes the configuration to lowercase after the conditioning has been applied.