### PR TITLE
fix-ci

### DIFF
--- a/sv2-custom-proxy/Cargo.toml
+++ b/sv2-custom-proxy/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-demand-easy-sv2 = { version = "0.5.0", git = "https://github.com/demand-open-source/demand-easy-sv2" }
+demand-easy-sv2 = { version = "=0.6.0" }
 prometheus = "0.13"
 warp = "0.3"
 tokio = { version = "1.36.0", features = ["full", "tracing"] }


### PR DESCRIPTION
Due to the version bump of `demand-sv2-connection`, our CI build failed. This PR fixes the issue by directly fetching `demand-sv2-easy` from Cargo.