### PR TITLE
fix grafana version to 11.2.4 

### DIFF
--- a/docker-compose-config-a.yaml
+++ b/docker-compose-config-a.yaml
@@ -480,7 +480,7 @@ services:
         condition: on-failure
 
   grafana:
-    image: grafana/grafana
+    image: grafana/grafana:11.2.4
     depends_on:
       - prometheus
     ports:

--- a/docker-compose-config-c.yaml
+++ b/docker-compose-config-c.yaml
@@ -409,7 +409,7 @@ services:
         condition: on-failure
 
   grafana:
-    image: grafana/grafana
+    image: grafana/grafana:11.2.4
     depends_on:
       - prometheus
       - loki


### PR DESCRIPTION
This PR is a quick solution for #69.

Even if it's not ideal, it does the job. One alternative could have been to patch [reporter](https://github.com/IzakMarais/reporter/) but since it's unmaintained since years, we should have forked it and maintain the fork.

One other alternative could have been to open an issue on `grafana` repo and see what happens.

For now, I think it's fine to use this older version of `grafana` which works perfectly.

To test this PR:
- delete the local image you might have for grafana
- run the tool 
- select a random time-frame using your mouse on a random panel
- click Report
- waits for it to be generated

Closes #69 