### PR TITLE
Fix run script

### DIFF
--- a/docker-compose-config-a.yaml
+++ b/docker-compose-config-a.yaml
@@ -151,6 +151,8 @@ services:
     command: ["/bin/sh", "-c", "./monitor_and_apply_latency.sh 10.5.0.6 2 & exec ./pool_sv2 -c pool/config-examples/pool-config-a-docker-example.toml"]
     ports:
       - "34254:34254"
+    environment:
+      - RUST_LOG=${LOG_LEVEL}
     container_name: sv2-pool
     depends_on:
       template-provider-pool-side: 
@@ -179,6 +181,8 @@ services:
       ]
     ports:
       - "34264:34264"
+    environment:
+      - RUST_LOG=${LOG_LEVEL}
     container_name: sv2-jds
     depends_on:
       template-provider-pool-side: 
@@ -207,6 +211,8 @@ services:
       ]
     ports:
       - "34265:34265"
+    environment:
+      - RUST_LOG=${LOG_LEVEL}
     container_name: sv2-jdc
     volumes:
       - ./custom-configs/sri-roles/config-a:/usr/local/bin/jd-client/config-examples/
@@ -233,6 +239,8 @@ services:
       ]
     ports:
       - "34256:34256"
+    environment:
+      - RUST_LOG=${LOG_LEVEL}
     container_name: sv2-translator
     depends_on:
       - sv2-jdc-translator-proxy

--- a/docker-compose-config-c.yaml
+++ b/docker-compose-config-c.yaml
@@ -128,6 +128,8 @@ services:
       ]
     ports:
       - "34254:34254"
+    environment:
+      - RUST_LOG=${LOG_LEVEL}
     container_name: sv2-pool
     depends_on:
       - sv2-roles-builder
@@ -153,6 +155,8 @@ services:
       ]
     ports:
       - "34256:34256"
+    environment:
+      - RUST_LOG=${LOG_LEVEL}
     container_name: sv2-translator
     depends_on:
       - sv2-pool-translator-proxy

--- a/log-server/Cargo.toml
+++ b/log-server/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 dotenv = "0.15.0"
-reqwest = { version = "0.12.5", features = ["json"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 tar = "0.4.38"

--- a/run-benchmarking-tool.sh
+++ b/run-benchmarking-tool.sh
@@ -152,6 +152,7 @@ fi
 
 # Define all the configuration files to update
 CONFIG_FILES=(
+    "custom-configs/sri-roles/config-a/pool-config-a-docker-example.toml"
     "custom-configs/sri-roles/config-a/jds-config-a-docker-example.toml"
     "custom-configs/sri-roles/config-a/jdc-config-a-docker-example.toml"
     "custom-configs/sri-roles/config-c/pool-config-c-docker-example.toml"

--- a/sv1-custom-proxy/Cargo.toml
+++ b/sv1-custom-proxy/Cargo.toml
@@ -13,6 +13,6 @@ tracing-subscriber = "0.3"
 prometheus = "0.13"
 warp = "0.3"
 hyper = { version = "0.14", features = ["full"] }
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 hex = "0.4.3"
 env_logger = "0.11.6"

--- a/sv2-custom-proxy/Cargo.toml
+++ b/sv2-custom-proxy/Cargo.toml
@@ -9,7 +9,7 @@ prometheus = "0.13"
 warp = "0.3"
 tokio = { version = "1.36.0", features = ["full", "tracing"] }
 dotenv = "0.15.0"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 serde_json = "1.0.120"
 hex = "0.4.3"
 log = "0.4.22"


### PR DESCRIPTION
This PR adds the `custom-configs/sri-roles/config-a/pool-config-a-docker-example.toml` file into config to update by the `run-benchmarking-tool.sh` script.

It also introduces the customizable `LOG_LEVEL` to every SV2 roles.